### PR TITLE
Various QoL Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ datadogAgentHost := "127.0.0.1"
 You can use your **host** (where you code run) enviroment variables in the value:  
 
 ```scala
-datadogServiceName := "${MY_DD_HOST_IP}"
+datadogAgentHost := "${MY_DD_HOST_IP}"
 ```
 
 #### `datadogAgentPort`
@@ -134,6 +134,16 @@ To use another value, add the following to your `build.sbt` file:
 
 ```scala
 datadogEnableDebug := true
+```
+
+#### `datadogGlobalTags`
+
+A list of default tags to be added to every span and every JMX metric. Default value is an empty list.
+
+To add global tags:
+
+```scala
+datadogGlobalTags += ("key", "value")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To use another value, add the following to your `build.sbt` file:
 datadogServiceName := "another name"
 ```
 
-You can use your **host** (where you code run) enviroment variables in the value:  
+You can use your **host** (where you code run) environment variables in the value:  
 
 ```scala
 datadogServiceName := "another name ${MY_HOST_ENV_VAR}"
@@ -68,7 +68,7 @@ To use another value, add the following to your `build.sbt` file:
 datadogAgentHost := "127.0.0.1"
 ```
 
-You can use your **host** (where you code run) enviroment variables in the value:  
+You can use your **host** (where you code run) environment variables in the value:  
 
 ```scala
 datadogAgentHost := "${MY_DD_HOST_IP}"
@@ -84,7 +84,7 @@ To use another value, add the following to your `build.sbt` file:
 datadogAgentPort := 9999
 ```
 
-You can use your **host** (where you code run) enviroment variables in the value:  
+You can use your **host** (where you code run) environment variables in the value:  
 
 ```scala
 datadogAgentPort := "${MY_DD_PORT}"
@@ -100,7 +100,7 @@ To set the `env`, add the following to your `build.sbt` file:
 datadogEnv := "staging"
 ```
 
-You can use your **host** (where you code run) enviroment variables in the value:  
+You can use your **host** (where you code run) environment variables in the value:  
 
 ```scala
 datadogEnv := "${MY_ENV}"

--- a/src/main/scala/com/colisweb/sbt/DatadogAPM.scala
+++ b/src/main/scala/com/colisweb/sbt/DatadogAPM.scala
@@ -14,7 +14,7 @@ object DatadogAPM extends AutoPlugin {
 
   object autoImport {
     lazy val datadogApmVersion = settingKey[String]("Datadog APM agent version")
-    lazy val datadogJavaAgent  = taskKey[File]("Datagod agent jar location")
+    lazy val datadogJavaAgent  = taskKey[File]("Datadog agent jar location")
     lazy val datadogServiceName = taskKey[String](
       "The name of a set of processes that do the same job. Used for grouping stats for your application. Default value is the sbt project name")
     lazy val datadogAgentHost = taskKey[String](

--- a/src/main/scala/com/colisweb/sbt/DatadogAPM.scala
+++ b/src/main/scala/com/colisweb/sbt/DatadogAPM.scala
@@ -68,7 +68,7 @@ object DatadogAPM extends AutoPlugin {
       else """echo "Datadog debug mode disabled""""
     },
     bashScriptExtraDefines ++= datadogGlobalTags.value.map { case (key, value) =>
-      s"""addJava -Ddd.trace.global.tags=$key=$value"""
+      s"""addJava -Ddd.trace.global.tags=$key:$value"""
     }
   )
 

--- a/src/main/scala/com/colisweb/sbt/DatadogAPM.scala
+++ b/src/main/scala/com/colisweb/sbt/DatadogAPM.scala
@@ -14,7 +14,7 @@ object DatadogAPM extends AutoPlugin {
 
   object autoImport {
     lazy val datadogApmVersion = settingKey[String]("Datadog APM agent version")
-    lazy val datagodJavaAgent  = taskKey[File]("Datagod agent jar location")
+    lazy val datadogJavaAgent  = taskKey[File]("Datagod agent jar location")
     lazy val datadogServiceName = taskKey[String](
       "The name of a set of processes that do the same job. Used for grouping stats for your application. Default value is the sbt project name")
     lazy val datadogAgentHost = taskKey[String](
@@ -28,6 +28,9 @@ object DatadogAPM extends AutoPlugin {
       taskKey[Boolean]("Akka-Http Server and Lagom Framework Instrumentation. Default value: false")
     lazy val datadogEnableDebug =
       taskKey[Boolean]("To return debug level application logs, enable debug mode. Default value: false")
+    lazy val datadogGlobalTags = taskKey[Seq[(String, String)]](
+       "A list of default tags to be added to every span and every JMX metric. Default value: Empty List"
+    )
   }
   import autoImport._
 
@@ -37,8 +40,8 @@ object DatadogAPM extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     ivyConfigurations += DatadogConfig,
-    datadogApmVersion := "0.10.0",
-    datagodJavaAgent := findDatadogJavaAgent(update.value),
+    datadogApmVersion := "0.30.0",
+    datadogJavaAgent := findDatadogJavaAgent(update.value),
     datadogServiceName := name.value,
     datadogAgentHost := "localhost",
     datadogAgentPort := 8126,
@@ -46,8 +49,9 @@ object DatadogAPM extends AutoPlugin {
     datadogEnableNetty := false,
     datadogEnableAkkaHttp := false,
     datadogEnableDebug := false,
+    datadogGlobalTags := Nil,
     libraryDependencies += "com.datadoghq"          % "dd-java-agent" % datadogApmVersion.value % DatadogConfig,
-    mappings in Universal += datagodJavaAgent.value -> "datadog/dd-java-agent.jar",
+    mappings in Universal += datadogJavaAgent.value -> "datadog/dd-java-agent.jar",
     bashScriptExtraDefines += """addJava "-javaagent:${app_home}/../datadog/dd-java-agent.jar"""",
     bashScriptExtraDefines += s"""addJava "-Ddd.service.name=${datadogServiceName.value}"""",
     bashScriptExtraDefines += s"""addJava "-Ddd.agent.host=${datadogAgentHost.value}"""",
@@ -56,12 +60,15 @@ object DatadogAPM extends AutoPlugin {
     bashScriptExtraDefines += s"""addJava "-Ddd.integration.akka-http.enabled=${datadogEnableAkkaHttp.value}"""",
     bashScriptExtraDefines += {
       val env = datadogEnv.value
-      if (env.nonEmpty) s"""addJava "-Ddd.trace.span.tags=env:$env"""" else """echo "Datadog env is not set""""
+      if (env.nonEmpty) s"""addJava "-Ddd.trace.global.tags=env:$env"""" else """echo "Datadog env is not set""""
     },
     bashScriptExtraDefines += {
       val debugEnabled = datadogEnableDebug.value
       if (debugEnabled) s"""addJava "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug""""
       else """echo "Datadog debug mode disabled""""
+    },
+    bashScriptExtraDefines ++= datadogGlobalTags.value.map { case (key, value) =>
+      s"""addJava -Ddd.trace.global.tags=$key=$value"""
     }
   )
 


### PR DESCRIPTION
* Fixed some typos in README and variable names
* Update default DD agent to v 0.30.0
* Added sbt project setting for global tags
* Updated `env` key to be a global tag rather than span one (not sure if this was intentional or not, but I think it makes more sense to be global). I found that when the `env` is set for the span scope, JMX metrics collected by the agent are not able to be properly associated with the right service APM.